### PR TITLE
Fix the case when publish_tf is false, child_frame_id is not

### DIFF
--- a/vicon_odom/launch/vicon_odom.launch
+++ b/vicon_odom/launch/vicon_odom.launch
@@ -5,10 +5,9 @@
   <arg name="output" default="screen"/>
 
   <node pkg="vicon_odom" type="vicon_odom" name="$(arg model)"
-    output="$(arg output)">
+    output="$(arg output)" ns="vicon">
     <param name="child_frame_id" type="string" value="$(arg child_frame_id)"/>
     <param name="publish_tf" type="bool" value="$(arg publish_tf)"/>
-    <param name="model" type="string" value="$(arg model)"/>
     <remap from="~vicon_subject" to="$(arg model)"/>
   </node>
 </launch>

--- a/vicon_odom/src/vicon_odom.cpp
+++ b/vicon_odom/src/vicon_odom.cpp
@@ -10,7 +10,8 @@ ViconOdom::ViconOdom(ros::NodeHandle &nh)
   double max_accel;
   nh.param("max_accel", max_accel, 5.0);
   nh.param("publish_tf", publish_tf_, false);
-  if(publish_tf_ && !nh.getParam("child_frame_id", child_frame_id_))
+  nh.param<std::string>("child_frame_id", child_frame_id_, "base_link");
+  if(publish_tf_ && child_frame_id_.empty())
     throw std::runtime_error("vicon_odom: child_frame_id required for publishing tf");
 
   // There should only be one vicon_fps, so we read from nh


### PR DESCRIPTION
Fix the case when `publish_tf` is false, `child_frame_id` is not read from parameter server thus the vicon odom message header has an empty child_frame_id.